### PR TITLE
Merge pull request #199 from BassT23/develop

### DIFF
--- a/check-updates.sh
+++ b/check-updates.sh
@@ -12,6 +12,11 @@ VERSION="1.7.1"
 #Variable / Function
 LOCAL_FILES="/etc/ultimate-updater"
 CONFIG_FILE="$LOCAL_FILES/update.conf"
+# Tag helper (if installed)
+if [[ -f "$LOCAL_FILES/tag-filter.sh" ]]; then
+  # shellcheck disable=SC1091
+  . "$LOCAL_FILES/tag-filter.sh"
+fi
 
 # Colors
 BL="\e[36m"
@@ -90,6 +95,9 @@ READ_WRITE_CONFIG () {
   PAUSED_VM=$(awk -F'"' '/^CHECK_PAUSED_VM=/ {print $2}' $CONFIG_FILE)
   EXCLUDED=$(awk -F'"' '/^EXCLUDE_UPDATE_CHECK=/ {print $2}' $CONFIG_FILE)
   ONLY=$(awk -F'"' '/^ONLY_UPDATE_CHECK=/ {print $2}' $CONFIG_FILE)
+  if declare -f apply_only_exclude_tags >/dev/null 2>&1; then
+    apply_only_exclude_tags ONLY EXCLUDED
+  fi
 }
 
 ## HOST ##

--- a/install.sh
+++ b/install.sh
@@ -212,6 +212,9 @@ INSTALL () {
     chmod -R +x "$LOCAL_FILES"/exit/*.sh
     cp "$TEMP_FILES"/scripts.d/000/* $LOCAL_FILES/scripts.d/000/
     cp "$TEMP_FILES"/update-extras.sh $LOCAL_FILES/update-extras.sh
+    if [[ -f "$TEMP_FILES/tag-filter.sh" ]]; then
+      cp "$TEMP_FILES"/tag-filter.sh $LOCAL_FILES/tag-filter.sh
+    fi
     cp "$TEMP_FILES"/update.conf $LOCAL_FILES/update.conf
     echo -e "${OR}Finished. Run The Ultimate Updater with 'update'.${CL}"
     echo -e "For infos and warnings please check the readme under <https://github.com/BassT23/Proxmox>\n"
@@ -267,6 +270,9 @@ UPDATE () {
     else
       rm -rf "$TEMP_FILES"/welcome-screen.sh || true
       rm -rf "$TEMP_FILES"/check-updates.sh || true
+    fi
+    if [[ -f "$TEMP_FILES/tag-filter.sh" ]]; then
+      mv "$TEMP_FILES"/tag-filter.sh $LOCAL_FILES/tag-filter.sh
     fi
     # Check if files are different
     rm -rf "$TEMP_FILES"/.github || true

--- a/tag-filter.sh
+++ b/tag-filter.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Proxmox VM/CT Tag & ID Expansion Helper
+#
+# apply_only_exclude_tags ONLY_VAR_NAME EXCLUDE_VAR_NAME
+# Expands ONLY (or if empty, EXCLUDE) into a space-separated list of numeric VMIDs.
+# Supports:
+#   - Plain VMIDs: 101 202
+#   - Delimiters: commas / semicolons / pipes / spaces intermixed (e.g. 101,202;203|204)
+#   - Ranges: 120-125 (inclusive)
+#   - Mixed IDs + ranges + tags: 110 testing 111 200-202
+#   - Uppercase user tag input (config tags assumed already lowercase)
+#     Tag tokens are any token not matching ^[0-9]+$ or ^[0-9]+-[0-9]+$.
+#   - OR matching across tag tokens.
+#
+# Behavior summary:
+#   1. Tokenize ONLY if set; else tokenized EXCLUDE.
+#   2. For each token:
+#        number        -> add as VMID
+#        range a-b     -> expand (a..b)
+#        tag           -> collect tag for later resolution
+#   3. Resolve tags to IDs (any tag match) and append, de-duplicating while
+#      preserving first-seen order (input order then discovery order for tags).
+#   4. Assign final space-separated list back to ONLY / EXCLUDE variable.
+#   5. If ONLY provided, EXCLUDE is ignored (legacy behavior).
+#
+# Usage examples:
+#   export ONLY="backup,windows"; apply_only_exclude_tags ONLY EXCLUDE; echo "$ONLY"
+#   export ONLY="101,102,105-107"; apply_only_exclude_tags ONLY EXCLUDE; echo "$ONLY"
+#   export ONLY="110 testtag 111 120-121"; apply_only_exclude_tags ONLY EXCLUDE; echo "$ONLY"
+#   export ONLY="" EXCLUDE="old 300-302"; apply_only_exclude_tags ONLY EXCLUDE; echo "$EXCLUDE"
+#
+# Notes: Always returns 0. Bash-only (arrays, process substitution). Inherits repo license.
+# shellcheck shell=bash
+# shellcheck disable=SC2155  # Command substitution in local assignment is intentional
+# shellcheck disable=SC2086  # Intended word splitting for tag token arrays
+
+apply_only_exclude_tags() {
+  local _only_var_name=$1 _exclude_var_name=$2
+
+  # Validate arguments: both variable names must be provided.
+  [[ -z $_only_var_name || -z $_exclude_var_name ]] && return 0
+
+  # Indirect expansion: read caller-provided variables.
+  local _ONLY_VALUE="${!_only_var_name}" _EXCLUDE_VALUE="${!_exclude_var_name}"
+  [[ -z $_ONLY_VALUE && -z $_EXCLUDE_VALUE ]] && return 0
+
+  # ------------------------------------------------------------------------
+  # Helper: gather all relevant Proxmox config files (unique list)
+  # ------------------------------------------------------------------------
+  _gather_conf_files() {
+    local f d nd
+    # Top-level qemu + lxc
+    for d in /etc/pve/qemu-server /etc/pve/lxc; do
+      [[ -d $d ]] || continue
+      for f in "$d"/*.conf; do [[ -f $f ]] && echo "$f"; done
+    done
+    # Per-node directories
+    for nd in /etc/pve/nodes/*; do
+      [[ -d $nd ]] || continue
+      for d in "$nd"/qemu-server "$nd"/lxc; do
+        [[ -d $d ]] || continue
+        for f in "$d"/*.conf; do [[ -f $f ]] && echo "$f"; done
+      done
+    done | sort -u
+  }
+
+  # ------------------------------------------------------------------------
+  # Helper: Build "tag map" lines: <vmid> <tag1> <tag2> ...
+  # Each tag list is normalized to lowercase and tokens separated by single spaces.
+  # ------------------------------------------------------------------------
+  _build_tag_map() {
+    local f id tline tags norm
+    while read -r f; do
+      [[ -f $f ]] || continue
+      id="$(basename "$f" .conf)"; [[ $id =~ ^[0-9]+$ ]] || continue
+      # Capture the first tags line (if any)
+      tline=$(grep -i '^tags:' "$f" 2>/dev/null | head -n1 || true)
+      [[ -n $tline ]] || continue
+      tags=${tline#*:}
+      # Lowercase + translate ; , | to spaces
+      tags=$(echo "$tags" | tr '[:upper:];,|' '[:lower:]   ')
+      # Normalize collapse whitespace & ensure trailing space separation for matching
+      norm=$(echo "$tags" | xargs -n1 echo 2>/dev/null | tr '\n' ' ')
+      echo "$id $norm"
+    done < <(_gather_conf_files)
+  }
+
+  # ------------------------------------------------------------------------
+  # Helper: Resolve a list of tag tokens -> space separated unique numeric IDs
+  # ------------------------------------------------------------------------
+  _resolve_ids_for_tags() {
+    local tag_arr=() tok
+    for tok in "$@"; do
+      [[ -n $tok ]] || continue
+      # Lowercase per comparison logic
+      tag_arr+=("$(echo "$tok" | tr '[:upper:]' '[:lower:]')")
+    done
+    [[ ${#tag_arr[@]} -gt 0 ]] || return 0
+
+    local matched=() line id rest t
+    while read -r line; do
+      id=${line%% *}; rest=" $line "
+      for t in "${tag_arr[@]}"; do
+        if [[ $rest == *" $t "* ]]; then
+          matched+=("$id")
+          break
+        fi
+      done
+    done < <(_build_tag_map)
+
+    # De-duplicate while preserving original encounter order.
+    local out=() seen=""
+    for id in "${matched[@]}"; do
+      if [[ ! $seen =~ (\s|^)$id(\s|$) ]]; then
+        out+=("$id")
+        seen+=" $id"
+      fi
+    done
+    echo "${out[*]}"
+  }
+
+  # ------------------------------------------------------------------------
+  # ------------------------------------------------------------------------
+  # Token parsing + expansion logic (shared by ONLY / EXCLUDE)
+  # ------------------------------------------------------------------------
+  _expand_mixed_spec() {
+    # $1: raw spec string
+    local raw=$1
+    [[ -n $raw ]] || return 0
+    local normalized
+    # Replace delimiters with spaces
+    normalized=$(echo "$raw" | tr ',;|' '   ')
+    # shellcheck disable=SC2206
+    local tokens=( $normalized )
+    local numbers=() tag_tokens=() t start end n
+    for t in "${tokens[@]}"; do
+      if [[ $t =~ ^[0-9]+$ ]]; then
+        numbers+=("$t")
+        continue
+      fi
+      if [[ $t =~ ^([0-9]+)-([0-9]+)$ ]]; then
+        start=${BASH_REMATCH[1]} end=${BASH_REMATCH[2]}
+        if (( start <= end )); then
+          for (( n=start; n<=end; n++ )); do numbers+=("$n"); done
+        else
+          # If reversed range, swap (user convenience)
+          for (( n=end; n<=start; n++ )); do numbers+=("$n"); done
+        fi
+        continue
+      fi
+        # Tag token (case-insensitive user input) -> store lowercase
+      tag_tokens+=("${t,,}")
+    done
+
+    local resolved_ids=""
+    if [[ ${#tag_tokens[@]} -gt 0 ]]; then
+      resolved_ids=$(_resolve_ids_for_tags "${tag_tokens[@]}")
+    fi
+
+    # Merge numeric IDs (in user order & range expansion order) + tag IDs (discovery order)
+    local final=() seen=""
+    for n in "${numbers[@]}"; do
+      if [[ ! $seen =~ (\s|^)$n(\s|$) ]]; then final+=("$n"); seen+=" $n"; fi
+    done
+    if [[ -n $resolved_ids ]]; then
+      # shellcheck disable=SC2206
+      local tag_ids=( $resolved_ids ) id
+      for id in "${tag_ids[@]}"; do
+        if [[ ! $seen =~ (\s|^)$id(\s|$) ]]; then final+=("$id"); seen+=" $id"; fi
+      done
+    fi
+
+    echo "${final[*]}"
+  }
+
+  # ONLY processing (takes precedence). Always parse mixed spec.
+  if [[ -n $_ONLY_VALUE ]]; then
+    local _expanded_only
+    _expanded_only=$(_expand_mixed_spec "$_ONLY_VALUE")
+    printf -v "$_only_var_name" '%s' "$_expanded_only"
+    if [[ -n $_expanded_only ]]; then
+      echo -e "${BL:-}[Info]${OR:-} Selection (ONLY='${_ONLY_VALUE}') -> IDs: $_expanded_only${CL:-}" 2>/dev/null || true
+    else
+      echo -e "${BL:-}[Info]${OR:-} Selection (ONLY='${_ONLY_VALUE}') matched no IDs${CL:-}" 2>/dev/null || true
+    fi
+    return 0
+  fi
+
+  # EXCLUDE processing (only when ONLY was empty)
+  if [[ -n $_EXCLUDE_VALUE ]]; then
+    local _expanded_exclude
+    _expanded_exclude=$(_expand_mixed_spec "$_EXCLUDE_VALUE")
+    printf -v "$_exclude_var_name" '%s' "$_expanded_exclude"
+    if [[ -n $_expanded_exclude ]]; then
+      echo -e "${BL:-}[Info]${OR:-} Exclusion (EXCLUDE='${_EXCLUDE_VALUE}') -> IDs: $_expanded_exclude${CL:-}" 2>/dev/null || true
+    else
+      echo -e "${BL:-}[Info]${OR:-} Exclusion (EXCLUDE='${_EXCLUDE_VALUE}') matched no IDs${CL:-}" 2>/dev/null || true
+    fi
+  fi
+}

--- a/welcome-screen.sh
+++ b/welcome-screen.sh
@@ -102,6 +102,13 @@ READ_WRITE_CONFIG () {
   STOPPED=$(awk -F'"' '/^CHECK_STOPPED_CONTAINER=/ {print $2}' $CONFIG_FILE)
   EXCLUDED=$(awk -F'"' '/^EXCLUDE_UPDATE_CHECK=/ {print $2}' $CONFIG_FILE)
   ONLY=$(awk -F'"' '/^ONLY_UPDATE_CHECK=/ {print $2}' $CONFIG_FILE)
+  if [[ -f "$LOCAL_FILES/tag-filter.sh" ]]; then
+    # shellcheck disable=SC1091
+    . "$LOCAL_FILES/tag-filter.sh"
+    if declare -f apply_only_exclude_tags >/dev/null 2>&1; then
+      apply_only_exclude_tags ONLY EXCLUDED
+    fi
+  fi
   if [[ $ONLY != "" ]]; then
     echo -e "${OR}Only is set. Not all machines are checked.${CL}\n"
   elif [[ $ONLY == "" && $EXCLUDED != "" ]]; then


### PR DESCRIPTION
Description: Introduce tag-filter.sh: expands ONLY / EXCLUDE specifications into a normalized space‑separated VMID list, supporting mixed tokens (IDs, ranges, tags). Converts to list of VMIDs so existing downstream logic continues to work.

Resolves: https://github.com/BassT23/Proxmox/issues/214

Key New Features:

- Mixed VMID, range, and tag tokens in a single ONLY / EXCLUDE value (e.g. 110 test 200-202).
- VMID range support (120-125 -> 120 121 122 123 124 125; reversed 205-203 handled).
- Delimiter normalization (spaces / commas / semicolons / pipes all accepted).
- Automatic lowercase handling for user tag inputs (config tags already lowercase).
- Mixed numeric + tag inputs resolved (was not supported before).
- De-duplication with stable ordering (explicit numbers/ranges first, then tag-derived IDs).
- Unified parsing logic; legacy precedence retained (ONLY overrides EXCLUDE).


Examples:

- ONLY numeric list normalization: ONLY="101,102;103|104" -> 101 102 103 104
- Mixed numeric + tag: ONLY="101 testtag" includes 101 plus IDs that carry testtag.
- Range expansion: ONLY="200-203" -> 200 201 202 203
- Reversed range: ONLY="205-203" -> 203 204 205
- Combined: ONLY="101,200-201 backup,windows" merges explicit + tag-derived IDs.
- EXCLUDE with ONLY unset: EXCLUDE="old 300-301" -> proper expansion.
- Tag not found: ONLY="nonexistenttag" -> empty (logged informational message).
- Deduplication: ONLY="101 100-102" -> 101 100 102 (order preserved, no duplicate 101 or 102 if matched by a tag as well).