### PR TITLE
update "community-scripts" without whiptail and expect involved

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.repository, 'BassT23/Proxmox') }}
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true

--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.repository, 'BassT23/Proxmox') }}
     steps:
-      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
+      - uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true

--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.repository, 'BassT23/Proxmox') }}
     steps:
-      - uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10.1.0
+      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10.1.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,6 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout code
-          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+          uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         - name: (Lint) Run ShellCheck
           uses: ludeeus/action-shellcheck@master # v2.0.0

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,6 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout code
-          uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+          uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         - name: (Lint) Run ShellCheck
           uses: ludeeus/action-shellcheck@master # v2.0.0

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,6 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout code
-          uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+          uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         - name: (Lint) Run ShellCheck
           uses: ludeeus/action-shellcheck@master # v2.0.0

--- a/update-extras.sh
+++ b/update-extras.sh
@@ -135,14 +135,6 @@ fi
 apt-get install expect -y
 if grep -q "community-scripts" /usr/bin/update 2>/dev/null && [[ $INCLUDE_HELPER_SCRIPTS == true ]]; then
   echo -e "\n*** Updating Community-Scripts ***"
-  expect <<EOF > /dev/null 2>&1
-    set timeout 3
-    spawn update
-    expect "Choose an option:"
-    send "2\r"
-    expect "<Ok>"
-    send "\r"
-    expect eof
-EOF
+  PHS_SILENT=1 update > /dev/null 2>&1
   echo -e "✅ Update process completed\n"
 fi

--- a/update-extras.sh
+++ b/update-extras.sh
@@ -132,7 +132,6 @@ if [[ $DOCKER_COMPOSE_V1 == true || $DOCKER_COMPOSE_V2 == true ]] && [[ $DOCKER_
 fi
 
 # Community / Helper Scripts
-apt-get install expect -y
 if grep -q "community-scripts" /usr/bin/update 2>/dev/null && [[ $INCLUDE_HELPER_SCRIPTS == true ]]; then
   echo -e "\n*** Updating Community-Scripts ***"
   PHS_SILENT=1 update > /dev/null 2>&1


### PR DESCRIPTION
# Problem
The `update-extra.sh` script currently attempts to automate the update function of the [community-scripts](https://github.com/community-scripts/ProxmoxVE) by using `expect` to send a numeric hotkey to `whiptail`.

This approach is flawed because `whiptail` does not support numeric hotkeys. Instead, it only accepts the first letter of the menu tag as a hotkey.
As a result, the expected input is not processed and the update flow does not proceed as intended.

# Root Cause

- `update-extra.sh` assumes that `whiptail` supports numeric menu selection
- `expect` sends a numeric key to `whiptail`
- `whiptail` only recognizes alphabetic hotkeys based on the menu tag

This is expected and documented behavior of `whiptail`.

# Solution

The update function of the `community-scripts` already supports a non-interactive execution mode via the environment variable: `PHS_SILENT=1`


When this variable is set:

- `whiptail` is completely bypassed
- the update runs in silent / non-interactive mode
- the expect dependency becomes unnecessary
- all `whiptail`-related input handling can be removed