### PR TITLE
feat: Make backup mode configurable (support for HA clusters)

### DIFF
--- a/update.conf
+++ b/update.conf
@@ -90,6 +90,13 @@ BACKUP="false"
 # when snaphot is enabled and LXC has mointpoint, snapshot is not possible;
 # make backup insead?
 BACKUP_LXC_MP="true"
+# Backup Mode
+# Choose the mode for the backup: "stop", "suspend", or "snapshot".
+# "stop" = Stops the VM/CT (Highest consistency, causes downtime). NOT compatible with HA.
+# "suspend" = Suspends the VM/CT (Good consistency, minimal downtime). Compatible with HA.
+# "snapshot" = Live backup (Lowest consistency, no downtime). Requires supported storage (e.g., LVM-Thin, ZFS, Ceph).
+# Default: stop
+BACKUP_MODE="stop"
 
 ┌──────────────────────────────────────────────┐
 │                Extra Updates                 │

--- a/update.sh
+++ b/update.sh
@@ -452,8 +452,10 @@ CONTAINER_BACKUP () {
       fi
     fi
     if [[ "$BACKUP" == true ]]; then
+      # Use BACKUP_MODE from config, default to 'stop' if not set
+      MODE=${BACKUP_MODE:-stop}
       echo -e "💾${OR:-} Create a backup for LXC (this will take some time - please wait)${CL:-}"
-      vzdump "$CONTAINER" --mode stop --notes-template "{{guestname}} - Ultimate-Updater" --storage "$(pvesm status -content backup | grep -m 1 -v ^Name | cut -d ' ' -f1)" --compress zstd
+      vzdump "$CONTAINER" --mode "$MODE" --notes-template "{{guestname}} - Ultimate-Updater" --storage "$(pvesm status -content backup | grep -m 1 -v ^Name | cut -d ' ' -f1)" --compress zstd
       echo -e "✅${GN:-} Backup created${CL:-}\n"
       if [[ $BACKUP_RESET == true ]]; then
         BACKUP=$(awk -F'"' '/^BACKUP=/ {print $2}' "$CONFIG_FILE")
@@ -480,8 +482,10 @@ VM_BACKUP () {
       fi
     fi
     if [[ "$BACKUP" == true ]]; then
+      # Use BACKUP_MODE from config, default to 'stop' if not set
+      MODE=${BACKUP_MODE:-stop}
       echo -e "💾${OR:-} Create a backup for the VM (this will take some time - please wait)${CL:-}"
-      vzdump "$VM" --mode stop --storage "$(pvesm status -content backup | grep -m 1 -v ^Name | cut -d ' ' -f1)" --compress zstd
+      vzdump "$VM" --mode "$MODE" --storage "$(pvesm status -content backup | grep -m 1 -v ^Name | cut -d ' ' -f1)" --compress zstd
       echo -e "✅${GN:-} Backup created${CL:-}"
     fi
   else

--- a/update.sh
+++ b/update.sh
@@ -417,6 +417,7 @@ READ_CONFIG () {
   KEEP_SNAPSHOT=$(awk -F'"' '/^KEEP_SNAPSHOT/ {print $2}' "$CONFIG_FILE")
   BACKUP=$(awk -F'"' '/^BACKUP=/ {print $2}' "$CONFIG_FILE")
   BACKUP_LXC_MP=$(awk -F'"' '/^BACKUP_LXC_MP=/ {print $2}' "$CONFIG_FILE")
+  BACKUP_MODE=$(awk -F'"' '/^BACKUP_MODE=/ {print $2}' "$CONFIG_FILE")
   LXC_START_DELAY=$(awk -F'"' '/^LXC_START_DELAY=/ {print $2}' "$CONFIG_FILE")
   VM_START_DELAY=$(awk -F'"' '/^VM_START_DELAY=/ {print $2}' "$CONFIG_FILE")
   EXTRA_GLOBAL=$(awk -F'"' '/^EXTRA_GLOBAL=/ {print $2}' "$CONFIG_FILE")


### PR DESCRIPTION
Currently, the script hardcodes `--mode stop` when performing backups. 
This causes backups to fail for any Container/VM managed by Proxmox HA (High Availability), as HA prevents the "stop" command to ensure uptime.

This PR adds a `BACKUP_MODE` variable to `update.conf`.
- Users can now set `BACKUP_MODE="suspend"` to support HA clusters.
- Defaults to `stop` if the variable is not set, preserving existing behavior for current users.