### PR TITLE
fix linux mint vm updating

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1037,7 +1037,7 @@ UPDATE_VM () {
         echo -e "${OR:-} Free BSD skipped by user${CL:-}\n"
         return
       # Debian Base
-      elif [[ "${OS,,}" =~ debian|ubuntu|linuxmint|neon|devuan ]]; then
+      elif [[ "${OS,,}" =~ debian|ubuntu|mint|neon|devuan ]]; then
         # Check Internet connection
         if ! ssh -q -p "$SSH_VM_PORT" "$USER"@"$IP" "$CHECK_URL_EXE" -c1 "$CHECK_URL" &>/dev/null; then
           echo -e "${OR:-} ❌ Internet check fail - skip this VM${CL:-}\n"


### PR DESCRIPTION
Updating a Linux Mint VM requires just the word mint adding to the OS check.

hostnamectl returns 

`Operating System: Linux Mint 22.3` 

Using linuxmint as the OS check will not update the VM.