### PR TITLE
Fix Linux Mint updating for SSH and QEMU connections

### DIFF
--- a/check-updates.sh
+++ b/check-updates.sh
@@ -317,7 +317,7 @@ CHECK_VM () {
 #          ssh -t -q -p "$SSH_VM_PORT" -tt "$USER"@"$IP" pkg update
 #          return
 #        fi
-        if [[ ${OS,,} =~ ubuntu|mint|debian|devuan ]]; then
+        if [[ ${OS,,} =~ ubuntu|mint|kali|debian|devuan ]]; then
           ssh -q -p "$SSH_VM_PORT" "$USER"@"$IP" "apt-get update" >/dev/null 2>&1
           APT_OUTPUT=$(ssh -q -p "$SSH_VM_PORT" "$USER"@"$IP" "apt-get -s upgrade")
           SECURITY_APT_UPDATES=$(echo "$APT_OUTPUT" | grep -ci '^inst.*security')
@@ -375,7 +375,7 @@ CHECK_VM_QEMU () {
 #      qm guest exec "$VM" -- tcsh -c "pkg update"
 #      return
 #    fi
-    if [[ ${OS,,} =~ ubuntu|mint|debian|devuan ]]; then
+    if [[ ${OS,,} =~ ubuntu|mint|kali|debian|devuan ]]; then
       qm guest exec "$VM" -- bash -c "apt-get update" >/dev/null 2>&1
       SECURITY_APT_UPDATES=$(qm guest exec "$VM" -- bash -c "apt-get -s upgrade | grep -ci ^inst.*security | tr -d '\n'" | tail -n +4 | head -n -1 | cut -c 18- | rev | cut -c 2- | rev)
       if [[ "$SECURITY_APT_UPDATES" -gt 0 ]]; then SECURITY_UPDATES_AVALABLE=true; fi

--- a/check-updates.sh
+++ b/check-updates.sh
@@ -317,7 +317,7 @@ CHECK_VM () {
 #          ssh -t -q -p "$SSH_VM_PORT" -tt "$USER"@"$IP" pkg update
 #          return
 #        fi
-        if [[ "$OS" =~ Ubuntu ]] || [[ "$OS" =~ Debian ]] || [[ "$OS" =~ Devuan ]]; then
+        if [[ ${OS,,} =~ ubuntu|mint|debian|devuan ]]; then
           ssh -q -p "$SSH_VM_PORT" "$USER"@"$IP" "apt-get update" >/dev/null 2>&1
           APT_OUTPUT=$(ssh -q -p "$SSH_VM_PORT" "$USER"@"$IP" "apt-get -s upgrade")
           SECURITY_APT_UPDATES=$(echo "$APT_OUTPUT" | grep -ci '^inst.*security')
@@ -375,7 +375,7 @@ CHECK_VM_QEMU () {
 #      qm guest exec "$VM" -- tcsh -c "pkg update"
 #      return
 #    fi
-    if [[ "$OS" =~ Ubuntu ]] || [[ "$OS" =~ Debian ]] || [[ "$OS" =~ Devuan ]]; then
+    if [[ ${OS,,} =~ ubuntu|mint|debian|devuan ]]; then
       qm guest exec "$VM" -- bash -c "apt-get update" >/dev/null 2>&1
       SECURITY_APT_UPDATES=$(qm guest exec "$VM" -- bash -c "apt-get -s upgrade | grep -ci ^inst.*security | tr -d '\n'" | tail -n +4 | head -n -1 | cut -c 18- | rev | cut -c 2- | rev)
       if [[ "$SECURITY_APT_UPDATES" -gt 0 ]]; then SECURITY_UPDATES_AVALABLE=true; fi

--- a/update.sh
+++ b/update.sh
@@ -1037,7 +1037,7 @@ UPDATE_VM () {
         echo -e "${OR:-} Free BSD skipped by user${CL:-}\n"
         return
       # Debian Base
-      elif [[ "${OS,,}" =~ debian|ubuntu|linuxmint|neon|devuan ]]; then
+      elif [[ "${OS,,}" =~ debian|ubuntu|mint|neon|devuan ]]; then
         # Check Internet connection
         if ! ssh -q -p "$SSH_VM_PORT" "$USER"@"$IP" "$CHECK_URL_EXE" -c1 "$CHECK_URL" &>/dev/null; then
           echo -e "${OR:-} ❌ Internet check fail - skip this VM${CL:-}\n"

--- a/update.sh
+++ b/update.sh
@@ -1141,7 +1141,7 @@ UPDATE_VM_QEMU () {
     elif [[ "$KERNEL" =~ FreeBSD ]]; then
       echo -e "${OR:-} Free BSD skipped by user${CL:-}\n"
       return
-    elif [[ ${OS,,} =~ ubuntu|debian|devuan ]]; then
+    elif [[ ${OS,,} =~ ubuntu|mint|debian|devuan ]]; then
       # Check Internet connection
       if ! (qm guest exec "$VM" -- bash -c "$CHECK_URL_EXE -q -c1 $CHECK_URL &>/dev/null"); then
         echo -e "${OR:-} ❌ Internet is not reachable - skip the update${CL:-}\n"

--- a/update.sh
+++ b/update.sh
@@ -1037,7 +1037,7 @@ UPDATE_VM () {
         echo -e "${OR:-} Free BSD skipped by user${CL:-}\n"
         return
       # Debian Base
-      elif [[ "${OS,,}" =~ debian|ubuntu|mint|neon|devuan ]]; then
+      elif [[ "${OS,,}" =~ debian|ubuntu|mint|kali|neon|devuan ]]; then
         # Check Internet connection
         if ! ssh -q -p "$SSH_VM_PORT" "$USER"@"$IP" "$CHECK_URL_EXE" -c1 "$CHECK_URL" &>/dev/null; then
           echo -e "${OR:-} ❌ Internet check fail - skip this VM${CL:-}\n"
@@ -1141,7 +1141,7 @@ UPDATE_VM_QEMU () {
     elif [[ "$KERNEL" =~ FreeBSD ]]; then
       echo -e "${OR:-} Free BSD skipped by user${CL:-}\n"
       return
-    elif [[ ${OS,,} =~ ubuntu|mint|debian|devuan ]]; then
+    elif [[ ${OS,,} =~ ubuntu|mint|kali|debian|devuan ]]; then
       # Check Internet connection
       if ! (qm guest exec "$VM" -- bash -c "$CHECK_URL_EXE -q -c1 $CHECK_URL &>/dev/null"); then
         echo -e "${OR:-} ❌ Internet is not reachable - skip the update${CL:-}\n"


### PR DESCRIPTION
Updating a Linux Mint VM requires just the word mint adding to the OS check.

hostnamectl returns

`Operating System: Linux Mint 22.3`

Using linuxmint as the OS check will not update the VM.