### PR TITLE
Fix backup failure not stopping update by checking vzdump exit code

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,6 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout code
-          uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         - name: (Lint) Run ShellCheck
           uses: ludeeus/action-shellcheck@master # v2.0.0

--- a/update.sh
+++ b/update.sh
@@ -453,8 +453,12 @@ CONTAINER_BACKUP () {
     fi
     if [[ "$BACKUP" == true ]]; then
       echo -e "💾${OR:-} Create a backup for LXC (this will take some time - please wait)${CL:-}"
-      vzdump "$CONTAINER" --mode stop --notes-template "{{guestname}} - Ultimate-Updater" --storage "$(pvesm status -content backup | grep -m 1 -v ^Name | cut -d ' ' -f1)" --compress zstd
-      echo -e "✅${GN:-} Backup created${CL:-}\n"
+      if vzdump "$CONTAINER" --mode stop --notes-template "{{guestname}} - Ultimate-Updater" --storage "$(pvesm status -content backup | grep -m 1 -v ^Name | cut -d ' ' -f1)" --compress zstd; then
+        echo -e "✅${GN:-} Backup created${CL:-}\n"
+      else
+        echo -e "❌${RD:-} Backup of LXC $CONTAINER failed - skipping update${CL:-}\n"
+        return 1
+      fi
       if [[ $BACKUP_RESET == true ]]; then
         BACKUP=$(awk -F'"' '/^BACKUP=/ {print $2}' "$CONFIG_FILE")
         SNAPSHOT=$(awk -F'"' '/^SNAPSHOT/ {print $2}' "$CONFIG_FILE")
@@ -481,8 +485,12 @@ VM_BACKUP () {
     fi
     if [[ "$BACKUP" == true ]]; then
       echo -e "💾${OR:-} Create a backup for the VM (this will take some time - please wait)${CL:-}"
-      vzdump "$VM" --mode stop --storage "$(pvesm status -content backup | grep -m 1 -v ^Name | cut -d ' ' -f1)" --compress zstd
-      echo -e "✅${GN:-} Backup created${CL:-}"
+      if vzdump "$VM" --mode stop --storage "$(pvesm status -content backup | grep -m 1 -v ^Name | cut -d ' ' -f1)" --compress zstd; then
+        echo -e "✅${GN:-} Backup created${CL:-}"
+      else
+        echo -e "❌${RD:-} Backup of VM $VM failed - skipping update${CL:-}"
+        return 1
+      fi
     fi
   else
     echo -e "⏩${OR:-} Snapshot and/or Backup skipped by the user${CL:-}"
@@ -586,7 +594,7 @@ DIST_UPGRADE () {
       SNAPSHOT=
       BACKUP=true
       echo
-      CONTAINER_BACKUP
+      CONTAINER_BACKUP || return
       echo -e "${GR:-}⏩ Upgrade to Debian 13 (Trixie) now:${CL:-}"
       echo -e "${OR:-}--- Enable stop on error ---\n${CL:-}"
       set -e
@@ -844,7 +852,7 @@ UPDATE_CONTAINER () {
   # Backup
   if [[ "$CHECK_DIST" != true ]]; then
     echo -e "💾${OR:-} Start Snapshot and/or Backup${CL:-}"
-    CONTAINER_BACKUP
+    CONTAINER_BACKUP || return
     echo
   fi
   # Run dist-upgrade
@@ -988,7 +996,7 @@ UPDATE_VM () {
   echo -e "🔄${GN:-} Updating VM ${BL:-}$VM${CL:-} : ${GN:-}$NAME${CL:-}\n"
   # Backup
   echo -e "💾${OR:-} Start Snapshot and/or Backup${CL:-}"
-  VM_BACKUP
+  VM_BACKUP || return
   echo
   # Read SSH config file - check how update is possible
   if [[ -f $LOCAL_FILES/VMs/"$VM" ]]; then


### PR DESCRIPTION
  - Check vzdump exit code for LXC and VM backups instead of unconditionally reporting success                                                                                                                                                                                                                                
  - Skip the update for a guest when its backup fails, preventing updates without a safety net                                                                                                                                                                                                                                
  - Applies to all three backup call sites: regular LXC updates, VM updates, and Debian dist-upgrades