### PR TITLE
Fix Unifi headless update flow and Docker Compose syntax error

### DIFF
--- a/update-extras.sh
+++ b/update-extras.sh
@@ -15,7 +15,6 @@ IOBROKER=$(awk -F'"' '/^IOBROKER=/ {print $2}' $CONFIG_FILE)
 PTERODACTYL=$(awk -F'"' '/^PTERODACTYL=/ {print $2}' $CONFIG_FILE)
 OCTOPRINT=$(awk -F'"' '/^OCTOPRINT=/ {print $2}' $CONFIG_FILE)
 DOCKER_COMPOSE=$(awk -F'"' '/^DOCKER_COMPOSE=/ {print $2}' $CONFIG_FILE)
-UNIFI=$(awk -F'"' '/^UNIFI=/ {print $2}' $CONFIG_FILE)
 COMPOSE_PATH=$(awk -F'"' '/^COMPOSE_PATH=/ {print $2}' $CONFIG_FILE)
 INCLUDE_HELPER_SCRIPTS=$(awk -F'"' '/^INCLUDE_HELPER_SCRIPTS=/ {print $2}' $CONFIG_FILE)
 
@@ -83,16 +82,6 @@ if [[ -d "/root/OctoPrint" && $OCTOPRINT == true ]]; then
   sudo service octoprint restart
 fi
 
-# Unifi Network Controller
-if [[ -d "/usr/lib/unifi" && $UNIFI == true ]]; then
-  echo -e "\n*** Updating Unifi Network Controller ***\n"
-  # --allow-releaseinfo-change needed because Unifi regularly changes repository metadata between versions
-  DEBIAN_FRONTEND=noninteractive apt-get update --allow-releaseinfo-change
-  DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
-    -o Dpkg::Options::="--force-confdef" \
-    -o Dpkg::Options::="--force-confold"
-fi
-
 # Docker Compose detection
 if [[ -f /usr/local/bin/docker-compose ]]; then DOCKER_COMPOSE_V1=true; fi
 if docker compose version &>/dev/null; then DOCKER_COMPOSE_V2=true; fi
@@ -114,7 +103,6 @@ if [[ $DOCKER_COMPOSE_V1 == true || $DOCKER_COMPOSE_V2 == true ]] && [[ $DOCKER_
       DIRLIST+=("$line")
     done < <(find "$COMPOSE_PATH" -name "$COMPOSEFILE" -exec dirname {} \; 2> >(grep -v 'Permission denied'))
   done
-fi
 
   # Docker-Compose v1
   if [[ $DOCKER_COMPOSE_V1 == true && ${#DIRLIST[@]} -gt 0 ]]; then

--- a/update.sh
+++ b/update.sh
@@ -876,16 +876,23 @@ UPDATE_CONTAINER () {
   # shellcheck disable=SC2015
   if [[ "${OS,,}" =~ ubuntu|debian|devuan ]]; then
     echo -e "${OR:-}--- APT UPDATE ---${CL:-}"
-    pct exec "$CONTAINER" -- bash -c "apt-get update -y" || ERROR_CODE=$? && ID=$CONTAINER && ERROR_MSG=$(pct exec "$CONTAINER" -- bash -c "apt-get update -y" 2>&1) || ERROR
+    # --allow-releaseinfo-change needed for repos that change metadata between versions (e.g. Unifi)
+    pct exec "$CONTAINER" -- bash -c "apt-get update --allow-releaseinfo-change" || ERROR_CODE=$? && ID=$CONTAINER && ERROR_MSG=$(pct exec "$CONTAINER" -- bash -c "apt-get update --allow-releaseinfo-change" 2>&1) || ERROR
     if [[ $ERROR_CODE != "" ]]; then return; fi
     # Check APT in Container
     if pct exec "$CONTAINER" -- bash -c "grep -rnw /etc/apt -e unifi >/dev/null 2>&1"; then
       UNIFI="true"
     fi
     # Check END
-    if [[ "$HEADLESS" == true || "$UNIFI" == true ]]; then
+    if [[ "$HEADLESS" == true ]]; then
       echo -e "\n${OR:-}--- APT UPGRADE HEADLESS ---${CL:-}"
       pct exec "$CONTAINER" -- bash -c "DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y" || ERROR_CODE=$? && ID=$CONTAINER && ERROR_MSG=$(pct exec "$CONTAINER" -- bash -c "DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y" 2>&1) || ERROR
+      UNIFI=""
+      if [[ $ERROR_CODE != "" ]]; then return; fi
+    elif [[ "$UNIFI" == true ]]; then
+      echo -e "\n${OR:-}--- APT UPGRADE HEADLESS (Unifi) ---${CL:-}"
+      # Use --force-confdef/--force-confold to suppress Unifi interactive prompts
+      pct exec "$CONTAINER" -- bash -c "DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'" || ERROR_CODE=$? && ID=$CONTAINER && ERROR_MSG=$(pct exec "$CONTAINER" -- bash -c "DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'" 2>&1) || ERROR
       UNIFI=""
       if [[ $ERROR_CODE != "" ]]; then return; fi
     else

--- a/update.sh
+++ b/update.sh
@@ -876,13 +876,15 @@ UPDATE_CONTAINER () {
   # shellcheck disable=SC2015
   if [[ "${OS,,}" =~ ubuntu|debian|devuan ]]; then
     echo -e "${OR:-}--- APT UPDATE ---${CL:-}"
-    # --allow-releaseinfo-change needed for repos that change metadata between versions (e.g. Unifi)
-    pct exec "$CONTAINER" -- bash -c "apt-get update --allow-releaseinfo-change" || ERROR_CODE=$? && ID=$CONTAINER && ERROR_MSG=$(pct exec "$CONTAINER" -- bash -c "apt-get update --allow-releaseinfo-change" 2>&1) || ERROR
-    if [[ $ERROR_CODE != "" ]]; then return; fi
-    # Check APT in Container
+    # Check APT in Container for Unifi before update
     if pct exec "$CONTAINER" -- bash -c "grep -rnw /etc/apt -e unifi >/dev/null 2>&1"; then
       UNIFI="true"
+      # --allow-releaseinfo-change needed because Unifi regularly changes repository metadata between versions
+      pct exec "$CONTAINER" -- bash -c "apt-get update --allow-releaseinfo-change" || ERROR_CODE=$? && ID=$CONTAINER && ERROR_MSG=$(pct exec "$CONTAINER" -- bash -c "apt-get update --allow-releaseinfo-change" 2>&1) || ERROR
+    else
+      pct exec "$CONTAINER" -- bash -c "apt-get update" || ERROR_CODE=$? && ID=$CONTAINER && ERROR_MSG=$(pct exec "$CONTAINER" -- bash -c "apt-get update" 2>&1) || ERROR
     fi
+    if [[ $ERROR_CODE != "" ]]; then return; fi
     # Check END
     if [[ "$HEADLESS" == true ]]; then
       echo -e "\n${OR:-}--- APT UPGRADE HEADLESS ---${CL:-}"


### PR DESCRIPTION
Background
PR #272 added Unifi support to update-extras.sh. After further analysis we found this approach was suboptimal: update.sh already runs apt-get update before extras are called, and a repository codename change (e.g. unifi-10.1 → unifi-10.2) blocks that update — meaning extras are never reached. Additionally, BassT23 already has Unifi-specific detection and a dedicated dist-upgrade path in update.sh (lines 882-889), making the extras approach redundant.

Changes
update.sh:
--allow-releaseinfo-change is scoped exclusively to containers with a Unifi apt repository to avoid silently accepting metadata changes in other containers.
Use apt-get update --allow-releaseinfo-change to handle Unifi repository metadata changes without blocking
Split Unifi into its own upgrade block with DEBIAN_FRONTEND=noninteractive + --force-confdef/--force-confold to suppress interactive prompts (backup confirmations, config file questions) during headless runs

update-extras.sh:

Remove Unifi block added in PR #272 — update.sh now handles it correctly and closer to the existing flow
Fix syntax error caused by misplaced fi in Docker Compose block introduced during the #272 merge