### PR TITLE
Fix: Replace brittle text parsing of qm guest exec JSON output with python3

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ contains(github.repository, 'BassT23/Proxmox') }}
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,6 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout code
-          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         - name: (Lint) Run ShellCheck
           uses: ludeeus/action-shellcheck@master # v2.0.0

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,6 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout code
-          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+          uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         - name: (Lint) Run ShellCheck
           uses: ludeeus/action-shellcheck@master # v2.0.0

--- a/.github/workflows/pull_request_labeler.yml
+++ b/.github/workflows/pull_request_labeler.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.repository == 'BassT23/Proxmox' }}
     steps:
       - name: Apply label
-        uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
+        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
         if: ${{ github.event_name == 'push' || github.event_name == 'pull_request_target'}}
         with:
           dirtyLabel: 'Merge conflict'

--- a/check-updates.sh
+++ b/check-updates.sh
@@ -367,8 +367,8 @@ CHECK_VM_QEMU () {
 #    fi
     if [[ "$OS" =~ Ubuntu ]] || [[ "$OS" =~ Debian ]] || [[ "$OS" =~ Devuan ]]; then
       qm guest exec "$VM" -- bash -c "apt-get update" >/dev/null 2>&1
-      SECURITY_APT_UPDATES=$(qm guest exec "$VM" -- bash -c "apt-get -s upgrade | grep -ci ^inst.*security | tr -d '\n'" | tail -n +4 | head -n -1 | cut -c 18- | rev | cut -c 2- | rev)
-      NORMAL_APT_UPDATES=$(qm guest exec "$VM" -- bash -c "apt-get -s upgrade | grep -ci ^inst. | tr -d '\n'" | tail -n +4 | head -n -1 | cut -c 18- | rev | cut -c 2- | rev)
+      SECURITY_APT_UPDATES=$(qm guest exec "$VM" -- bash -c "apt-get -s upgrade | grep -ci ^inst.*security" | python3 -c "import sys,json; print(json.load(sys.stdin).get('out-data','0').strip())")
+      NORMAL_APT_UPDATES=$(qm guest exec "$VM" -- bash -c "apt-get -s upgrade | grep -ci ^inst." | python3 -c "import sys,json; print(json.load(sys.stdin).get('out-data','0').strip())")
       if [[ $(qm guest exec "$VM" -- bash -c "[ -f /var/run/reboot-required.pkgs ]" | grep exitcode) =~ 0 ]]; then REBOOT_REQUIRED=true; fi
       if [[ "$SECURITY_APT_UPDATES" -gt 0 || "$NORMAL_APT_UPDATES" -gt 0 || "$REBOOT_REQUIRED" == true ]]; then
         echo -e "${GN}VM ${BL}$VM${CL} : ${GN}$NAME${CL}"
@@ -383,13 +383,13 @@ CHECK_VM_QEMU () {
       fi
     elif [[ "$OS" =~ Fedora ]]; then
       qm guest exec "$VM" -- bash -c "dnf -y update" >/dev/null 2>&1
-      UPDATES=$(qm guest exec "$VM" -- bash -c "dnf check-update | grep -Ec ' updates$'" | tail -n +4 | head -n -1 | cut -c 18- | rev | cut -c 2- | rev)
+      UPDATES=$(qm guest exec "$VM" -- bash -c "dnf check-update | grep -Ec ' updates$'" | python3 -c "import sys,json; print(json.load(sys.stdin).get('out-data','0').strip())")
       if [[ "$UPDATES" -gt 0 ]]; then
         echo -e "${GN}VM ${BL}$VM${CL} : ${GN}$NAME${CL}"
         echo -e "$UPDATES"
       fi
     elif [[ "$OS" =~ Arch ]]; then
-      UPDATES=$(qm guest exec "$VM" -- bash -c "pacman -Qu | wc -l" | tail -n +4 | head -n -1 | cut -c 18- | rev | cut -c 2- | rev)
+      UPDATES=$(qm guest exec "$VM" -- bash -c "pacman -Qu | wc -l" | python3 -c "import sys,json; print(json.load(sys.stdin).get('out-data','0').strip())")
       if [[ "$UPDATES" -gt 0 ]]; then
         echo -e "${GN}VM ${BL}$VM${CL} : ${GN}$NAME${CL}"
         echo -e "$UPDATES"
@@ -397,7 +397,7 @@ CHECK_VM_QEMU () {
     elif [[ "$OS" =~ Alpine ]]; then
       return
     elif [[ "$OS" =~ CentOS ]]; then
-      UPDATES=$(qm guest exec "$VM" -- bash -c "yum -q check-update | wc -l" | tail -n +4 | head -n -1 | cut -c 18- | rev | cut -c 2- | rev)
+      UPDATES=$(qm guest exec "$VM" -- bash -c "yum -q check-update | wc -l" | python3 -c "import sys,json; print(json.load(sys.stdin).get('out-data','0').strip())")
       if [[ "$UPDATES" -gt 0 ]]; then
         echo -e "${GN}VM ${BL}$VM${CL} : ${GN}$NAME${CL}"
         echo -e "$UPDATES"


### PR DESCRIPTION
**Problem**
On newer versions of Proxmox, check-updates.sh fails with repeated arithmetic errors when checking QEMU VMs via the guest agent (non-SSH):

```
./check-updates.sh: line 373: [[: 0"
" : : syntax error: invalid arithmetic operator (error token is ""
" : ")
```

The root cause is the pipeline used to extract update counts from qm guest exec output:

`| tail -n +4 | head -n -1 | cut -c 18- | rev | cut -c 2- | rev`

This pipeline assumes a fixed JSON field order and exact whitespace formatting. Newer Proxmox versions produce slightly different output, causing the extraction to return garbage values like 0"\n" : instead of just 0, which breaks every subsequent arithmetic comparison.

**Fix**
Replace all five instances of the brittle text pipeline with proper JSON parsing via python3:

`| python3 -c "import sys,json; print(json.load(sys.stdin).get('out-data','0').strip())"`

python3 is standard on all Proxmox/Debian hosts and handles any variation in field order, whitespace, or formatting.

**Testing**
Tested on Proxmox VE with Debian and Ubuntu guest VMs using the guest agent. No errors produced, update counts reported correctly.

Fixes #265

-Damon1974