### PR TITLE
fix: harden Community-Scripts update handling

### DIFF
--- a/change.log
+++ b/change.log
@@ -1,6 +1,9 @@
 Changelog:
 ==========
 
+**Unreleased / Hotfix candidate**
+- harden Community-Scripts updates with timeout and error reporting
+
 **v5.0** (11.08.2026)
 - change Logo
 - respect start delay from config also in check-updates

--- a/update-extras.sh
+++ b/update-extras.sh
@@ -135,6 +135,19 @@ fi
 # Community / Helper Scripts
 if grep -q "community-scripts" /usr/bin/update 2>/dev/null && [[ $INCLUDE_HELPER_SCRIPTS == true ]]; then
   echo -e "\n*** Updating Community-Scripts ***"
-  PHS_SILENT=1 update > /dev/null 2>&1
-  echo -e "✅ Update process completed\n"
+  COMMUNITY_UPDATE_LOG=$(mktemp)
+  if timeout 1800s env PHS_SILENT=1 update >"$COMMUNITY_UPDATE_LOG" 2>&1; then
+    echo -e "✅ Update process completed\n"
+  else
+    COMMUNITY_UPDATE_EXIT=$?
+    if [[ $COMMUNITY_UPDATE_EXIT == 124 ]]; then
+      echo -e "⚠️ Community-Scripts update timed out after 30 minutes"
+    else
+      echo -e "⚠️ Community-Scripts update failed with exit code $COMMUNITY_UPDATE_EXIT"
+    fi
+    echo -e "Community-Scripts output:\n"
+    cat "$COMMUNITY_UPDATE_LOG"
+    echo
+  fi
+  rm -f "$COMMUNITY_UPDATE_LOG"
 fi


### PR DESCRIPTION
## Summary

This draft PR carries the tested Community-Scripts robustness fix onto the published v5.0 base without merging any later `develop` changes.

## What changed

- add a 30-minute timeout around the external Community-Scripts updater
- preserve and print helper output on failure
- report the helper exit code
- avoid reporting false success
- clean up the temporary log afterwards

The v5.0 `update-extras.sh` behavior previously discarded stdout/stderr and ignored the helper exit code, so a real helper failure could look successful and an actual hang could block the whole updater indefinitely.

## Scope and provenance

- Base: published tag `v5.0` / master commit `1d260f7b3b5d18d211f5ddfaaabeabd0623f9fd7`
- Original tested develop commit: `5e0c7bc29d8fbbdfa3eb62a3071bde8778c4c15b`
- Hotfix commit: `0a15130cfe8ae31f5e97b0856c4ff55cac92866f`
- Tracking issue: #294

The concrete user-reported Zabbix hang has not been reproduced in the available test environment. The fix addresses the confirmed robustness weaknesses and is intended for additional user testing.

## Validation

- `bash -n update-extras.sh`
- `git diff --check`
- ShellCheck
- isolated success, failure, and timeout simulations
- real test-container failure path: exit code 203 and full output were reported without a false success message

Further user testing requested before deciding on a v5.0.x release.
