### PR TITLE
fix: load email recipient in update script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -432,7 +432,8 @@ READ_CONFIG () {
   PACMAN_ENVIRONMENT=$(awk -F'"' '/^PACMAN_ENVIRONMENT=/ {print $2}' "$CONFIG_FILE")
   declare -f apply_only_exclude_tags >/dev/null 2>&1 && apply_only_exclude_tags ONLY EXCLUDED
   EMAIL_ONLY_ERROR=$(awk -F'"' '/^EMAIL_ONLY_ERROR=/ {print $2}' "$CONFIG_FILE")
-  EMAIL_SENDER=$(awk -F'"' '/^EMAIL_SENDER=/ {print $2}' $CONFIG_FILE)
+  EMAIL_USER=$(awk -F'"' '/^EMAIL_USER=/ {print $2}' "$CONFIG_FILE")
+  EMAIL_SENDER=$(awk -F'"' '/^EMAIL_SENDER=/ {print $2}' "$CONFIG_FILE")
 }
 
 # Snapshot/Backup


### PR DESCRIPTION
## Summary

Load `EMAIL_USER` from `update.conf` in `update.sh`.

The v5.0 mail paths pass `$EMAIL_USER` to `mail`, but `READ_CONFIG()` currently never initializes it. This leaves the recipient empty and can make Postfix/sendmail fail with:

`fatal: $USER(0): No recipient addresses found in message header`

`check-updates.sh` already loads `EMAIL_USER`; this brings `update.sh` in line with it.

This was observed after the mail sender configuration added around #277.

## Verification

- `bash -n update.sh`
- targeted check that `READ_CONFIG()` initializes both `EMAIL_USER` and `EMAIL_SENDER`
- `git diff --check`
