### PR TITLE
chore: ignore local runtime and target files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,24 @@
 __pycache__/
 *.py[cod]
+
+# Keep per-target local update scripts out of Git. Only the upstream example
+# remains versioned so local scripts survive branch changes and resets.
+scripts.d/*
+!scripts.d/000/
+scripts.d/000/*
+!scripts.d/000/example.sh
+
+# Local runtime and generated state
+/build-metadata
+/check-output
+/mail-output
+/status.json
+/status.json.*
+/update.conf.lock
+/web-ui.conf
+/target-selection.json
+/internal-ssh.conf
+
+# Local backup files
+*.bak
+*.bak.*


### PR DESCRIPTION
## Summary

- keep per-target `scripts.d` files local while preserving the tracked upstream example
- ignore generated runtime state (`build-metadata`, `check-output`, `mail-output`, `status.json*`, `update.conf.lock`, `web-ui.conf`, `target-selection.json`)
- keep local SSH override data (`internal-ssh.conf`) out of Git
- ignore local backup files (`*.bak`, `*.bak.*`)

This prevents local target-specific scripts, generated runtime files, and local SSH override data from being accidentally tracked or overwritten during normal Git workflows.

The branch is based directly on the current `develop` head (`58a079a`).